### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/firefox/README.md
+++ b/firefox/README.md
@@ -1,2 +1,2 @@
-#Nepi Jano!
+# Nepi Jano!
 Read paid content on www.sme.sk

--- a/readme.md
+++ b/readme.md
@@ -4,102 +4,102 @@ Nepi Jano! extension 0.10.0
 Nepi Jano! is a extension for Google Chrome, Firefox & Safari that allows to read paid articles on [www.sme.sk](http://www.sme.sk).
  
 =======
-###Im not supporting this extension anymore. Feel free to fork it and make changes.
+### Im not supporting this extension anymore. Feel free to fork it and make changes.
 
 There is a fork that is maintained by @viliampucik https://github.com/viliampucik/nepi-jano.  Drop there for new versions.
 
 =======
  
-##Instalation / Update Google Chrome (0.10.0)
+## Instalation / Update Google Chrome (0.10.0)
 * [Download extension](https://github.com/ejci/nepi-jano/raw/master/releases/nepi_jano_0.10.0.crx.zip) (.zip)
 * Unzip downloaded file (.crx)
 * Type chrome://extensions in your Google Chrome browser
 * Drag and drop unziped (.crx) file to Google Chrome extensions tab
 
-###Alternative guide for Chrome 35+ on Windows
+### Alternative guide for Chrome 35+ on Windows
 * [Download extension](https://github.com/ejci/nepi-jano/raw/master/releases/nepi_jano_0.10.0.zip) (.zip)
 * Unzip downloaded file (.zip)
 * Type chrome://extensions in your Google Chrome browser
 * Enable "*Developer mode*"
 * "*Load unpacked extension...*" from folder where you unpacked the extension
 
-##Instalation / Update Safari (0.10.0)
+## Instalation / Update Safari (0.10.0)
 * [Download extension](https://github.com/ejci/nepi-jano/raw/master/releases/nepi_jano_0.10.0.safariextz) (.safariextz)
 * Doubleclick the downloaded .safariextz file
 * Pres *Install*
 
-##Installation / Update Firefox (0.10.0)
+## Installation / Update Firefox (0.10.0)
 * [Download addon](https://github.com/ejci/nepi-jano/raw/master/releases/nepi-jano_0.10.0.xpi)
 * New Tab -> Open File ... (Ctrl+O)
 * Select the downloaded addon (.xpi)
 * Press *Install Now*
 
 
-##How to use it
+## How to use it
 Just install extension and click on some paid link on [www.sme.sk](http://www.sme.sk) and wait for it...
 
-##How it works
+## How it works
 Read my blog posts about it: [2013.04.21](http://blog.ejci.net/2013/04/21/piano-and-sme-sk/), [2013.05.19](http://blog.ejci.net/2013/05/19/paid-content-for-free-on-slovak-news-portals/)
 
 ---
-##Disclaimer
+## Disclaimer
 This extension was made only for test purposes.
 Buy [Piano](http://www.pianomedia.sk) subscription. You wil save hungry children in Africa! Seriously. Don't be an asshole and buy subscription.
 
 ---
-#####Version
+##### Version
 * 0.10.0
 
-#####Author
+##### Author
 * [Miroslav Magda](http://ejci.net)
 
-#####Contrubitors
+##### Contrubitors
 * [Viliam Pucik](https://github.com/viliampucik) - Extension for Firefox
 * [Jakub Zitny](https://github.com/jakubzitny) - Extension for Safari
 * [Daniel Husar](https://github.com/danielhusar) - Various fixes
 
 ---
 
-##License
+## License
 All code is open source and dual licensed under GPL and MIT. Check the individual licenses for more information.
 
 
-###Change log
+### Change log
 
-####0.10.0
+#### 0.10.0
 * Update for sme.sk update of mobile app
 
-####0.9.7
+#### 0.9.7
 * Update for sme.sk redesign
 
-####0.9.6
+#### 0.9.6
 * Code cleanup 
 
-####0.9.5
+#### 0.9.5
 * another fix for hnonline.sk 
 
-####0.9.4
+#### 0.9.4
 * fix for hnonline.sk
      - after my report to hnonline.sk they fixed it so i made a simple workaround
 * etrend.sk support (piano paid content, content for subscribers)
 
-####0.9.3
+#### 0.9.3
 * partial support for hnonline.sk
 
-####0.9.2
+#### 0.9.2
 * jQuery 2.0.0
 * Bugfix (change link s.sme.sk/export/phone/?c=XXX to www.sme.sk/c/XXX/)
 
-####0.9.1
+#### 0.9.1
 * Bugfixes
 * Rewriting extension
 * View paid videos with custom HTML5 video player
 
-####0.9.0
+#### 0.9.0
 * View paid articles
 
-####0.1.2
+#### 0.1.2
 * Proof of concept working on Windows
 
-####0.1.1
+#### 0.1.1
 * Proof of concept (stand alone extension)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
